### PR TITLE
Fix console warning about input being null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,11 @@ class Geocoder extends Component {
     state = {
         results: [],
         showResults: false,
-        inputValue: null
+        inputValue: ''
     };
 
     static getDerivedStateFromProps(nextProps, state) {
-        if (state.inputValue === null && nextProps.initialInputValue !== '') {
+        if (state.inputValue.length === 0 && nextProps.initialInputValue !== '') {
             return {
                 inputValue: nextProps.initialInputValue
             };


### PR DESCRIPTION
Hi! Thanks so much for making this library available. Just a little tweak -- in my version of React `(16.13.1)`, I'm getting a console error for this initial input value being null -- here:

`Warning: 'value' prop on 'input' should not be null. Consider using the empty string to clear the component or 'undefined' for uncontrolled components.`

Changing the initial value from null to an empty string seems to make this error disappear from the console, at least, on my end! 👋 